### PR TITLE
Fixed rotate object acting like set rotation

### DIFF
--- a/Broken Engine/Source/ComponentCollider.cpp
+++ b/Broken Engine/Source/ComponentCollider.cpp
@@ -144,7 +144,7 @@ void ComponentCollider::UpdateLocalMatrix() {
 	ComponentDynamicRigidBody* dynamicRB = GO->GetComponent<ComponentDynamicRigidBody>();
 	ComponentTransform* cTransform = GO->GetComponent<ComponentTransform>();
 
-	if (!rigidStatic && !dynamicRB)
+	if (!rigidStatic && (!dynamicRB || !dynamicRB->rigidBody))
 		return;
 
 	math::float4x4 gt = cTransform->GetGlobalTransform();

--- a/Broken Engine/Source/ScriptingTransform.cpp
+++ b/Broken Engine/Source/ScriptingTransform.cpp
@@ -98,18 +98,25 @@ void ScriptingTransform::RotateObject(float x, float y, float z, uint gameobject
 			if (!rb->rigidBody)
 				return;
 
-			physx::PxTransform globalPos = rb->rigidBody->getGlobalPose();
-			Quat quaternion = Quat::FromEulerXYZ(DEGTORAD * x, DEGTORAD * y, DEGTORAD * z);
-			physx::PxQuat quat = physx::PxQuat(quaternion.x, quaternion.y, quaternion.z, quaternion.w);
-			globalPos = physx::PxTransform(globalPos.p, quat);
+			// We get current rotation in quaternions
+			float3 rot = transform->GetRotation();
+			Quat current_quat = Quat::FromEulerXYZ(DEGTORAD * rot.x, DEGTORAD * rot.y, DEGTORAD * rot.z);
 
+			// We calculate the quaternion of the new rotation and add them up
+			Quat quaternion = Quat::FromEulerXYZ(DEGTORAD * x, DEGTORAD * y, DEGTORAD * z);
+			quaternion = quaternion * current_quat;
+
+			physx::PxQuat quat = physx::PxQuat(quaternion.x, quaternion.y, quaternion.z, quaternion.w);
+		
+			physx::PxTransform globalPos = rb->rigidBody->getGlobalPose();
+			globalPos = physx::PxTransform(globalPos.p, quat);
 			collider->UpdateTransformByRigidBody(rb, transform, &globalPos);
 
 		}
 		else if (transform)
 		{
 			float3 rot = transform->GetRotation();
-			rot = float3(x, y, z);
+			rot += float3(x, y, z);
 			transform->SetRotation(rot);
 		}
 		else


### PR DESCRIPTION
## Testing checklist
Please make sure you mark with an "x" ([x]) all the tests you have done in the branch so it is easier to test it before merge

- [X] Merged branch development into it 
- [X] Compiles both in Release and Debug mode
- [x] Game build can be created and it launches without issue
- [X] I have checked and it has no memory leaks

## Description
Fixes RotateObject acting like SetRotation instead of adding up the rotations

## Related issues
Fixes #232 
