### PR TITLE
Fixed GetScript crashing when GO has no component script

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_issue_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_issue_template.md
@@ -19,6 +19,7 @@ Select the type of bug with and "x" ([x])
 * [ ] Components
 * [ ] Game Objects
 * [ ] UI/UX 
+* [ ] Scripting
 * [ ] Other
 
 ## Severity

--- a/Broken Engine/Source/ScriptingGameobject.cpp
+++ b/Broken Engine/Source/ScriptingGameobject.cpp
@@ -162,9 +162,11 @@ luabridge::LuaRef ScriptingGameobject::GetScript(uint gameobject_UUID, lua_State
 	if (go != nullptr)
 	{
 		ComponentScript* component_script = go->GetComponent<ComponentScript>();
-		ScriptInstance* script = App->scripting->GetScriptInstanceFromComponent(component_script);
+		if (component_script != nullptr) {
+			ScriptInstance* script = App->scripting->GetScriptInstanceFromComponent(component_script);
 
-		ret = script->my_table_class;
+			ret = script->my_table_class;
+		}
 	}
 	return ret;
 }


### PR DESCRIPTION
## Testing checklist
Please make sure you mark with an "x" ([x]) all the tests you have done in the branch so it is easier to test it before merge

- [X] Merged branch development into it 
- [X] Compiles both in Release and Debug mode
- [X] Game build can be created and it launches without issue
- [X] I have checked and it has no memory leaks

## Description
Fixes GetScript crashing when the GO sent has no component script

## Related issues
Fixes #247 

